### PR TITLE
Stop xmldom version at 0.1.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "debug": "^2.2.0",
     "jszip": "^2.4.0",
-    "xmldom": "^0.1.22",
+    "xmldom": "0.1.22",
     "xpath": "0.0.22"
   },
   "repository": {


### PR DESCRIPTION
XMLDom appears to have introduced bugs into xlsx-populate, fixing the version to 0.1.22 appears to fix these issues. Perhaps we should re-evaluate xlsx-populates dependancy on this library.