### PR TITLE
Added ability to parse cell `str` value

### DIFF
--- a/lib/Cell.js
+++ b/lib/Cell.js
@@ -558,6 +558,10 @@ class Cell {
             // String value.
             const sharedIndex = xmlq.findChild(node, 'v').children[0];
             this._value = this.workbook().sharedStrings().getStringByIndex(sharedIndex);
+        } else if (type === "str") {
+            // Simple string value.
+            const vNode = xmlq.findChild(node, 'v');
+            this._value = vNode && vNode.children[0];
         } else if (type === "inlineStr") {
             // Inline string value: can be simple text or rich text.
             const isNode = xmlq.findChild(node, 'is');

--- a/test/unit/Cell.spec.js
+++ b/test/unit/Cell.spec.js
@@ -814,6 +814,17 @@ describe("Cell", () => {
             expect(sharedStrings.getStringByIndex).toHaveBeenCalledWith(5);
         });
 
+        it("should parse simple string values", () => {
+            node.attributes.t = "str";
+            node.children = [{
+                name: 'v',
+                children: ['SIMPLE STRING']
+            }];
+
+            cell._parseNode(node);
+            expect(cell._value).toBe("SIMPLE STRING");
+        });
+
         it("should parse inline string values", () => {
             node.attributes.t = "inlineStr";
             node.children = [{


### PR DESCRIPTION
In cases when the value of a cell is a string - e.g. result
of formula like `VLOOKUP` now it is properly parsed.

Previously it returned `NaN` result as trying to parse it as `Number`