### PR TITLE
Add index validation

### DIFF
--- a/lib/Column.js
+++ b/lib/Column.js
@@ -2,6 +2,7 @@
 
 const ArgHandler = require("./ArgHandler");
 const addressConverter = require('./addressConverter');
+const indexValidation = require('./indexValidation');
 
 // Default column width.
 const defaultColumnWidth = 9.140625;
@@ -47,6 +48,7 @@ class Column {
      * @returns {Cell} The cell in the column with the given row number.
      */
     cell(rowNumber) {
+        indexValidation.validateIndex(rowNumber, "row");
         return this.sheet().cell(rowNumber, this.columnNumber());
     }
 

--- a/lib/Row.js
+++ b/lib/Row.js
@@ -5,6 +5,7 @@ const Cell = require("./Cell");
 const regexify = require("./regexify");
 const ArgHandler = require("./ArgHandler");
 const addressConverter = require('./addressConverter');
+const indexValidation = require('./indexValidation');
 
 /**
  * A row.
@@ -48,6 +49,8 @@ class Row {
         if (typeof columnNameOrNumber === 'string') {
             columnNumber = addressConverter.columnNameToNumber(columnNameOrNumber);
         }
+
+        indexValidation.validateIndex(columnNumber, "column");
 
         // Return an existing cell.
         if (this._cells[columnNumber]) return this._cells[columnNumber];
@@ -259,6 +262,7 @@ class Row {
      * @ignore
      */
     hasCell(columnNumber) {
+        indexValidation.validateIndex(columnNumber, "column");
         return !!this._cells[columnNumber];
     }
 

--- a/lib/Sheet.js
+++ b/lib/Sheet.js
@@ -85,8 +85,6 @@ class Sheet {
                 return this.cell(cellAddress);
             })
             .case(['number', '*'], (rowNumber, columnNameOrNumber) => {
-                indexValidation.validateIndex(rowNumber, "row");
-
                 const cell = this.cell(rowNumber, columnNameOrNumber);
                 return this.activeCell(cell);
             })

--- a/lib/Sheet.js
+++ b/lib/Sheet.js
@@ -9,6 +9,7 @@ const Relationships = require("./Relationships");
 const xmlq = require("./xmlq");
 const regexify = require("./regexify");
 const addressConverter = require("./addressConverter");
+const indexValidation = require("./indexValidation");
 const ArgHandler = require("./ArgHandler");
 const colorIndexes = require("./colorIndexes");
 
@@ -84,6 +85,8 @@ class Sheet {
                 return this.cell(cellAddress);
             })
             .case(['number', '*'], (rowNumber, columnNameOrNumber) => {
+                indexValidation.validateIndex(rowNumber, "row");
+
                 const cell = this.cell(rowNumber, columnNameOrNumber);
                 return this.activeCell(cell);
             })
@@ -120,9 +123,11 @@ class Sheet {
             .case('string', address => {
                 const ref = addressConverter.fromAddress(address);
                 if (ref.type !== 'cell') throw new Error('Sheet.cell: Invalid address.');
+                indexValidation.validateIndex(ref.rowNumber, "row");
                 return this.row(ref.rowNumber).cell(ref.columnNumber);
             })
             .case(['number', '*'], (rowNumber, columnNameOrNumber) => {
+                indexValidation.validateIndex(rowNumber, "row");
                 return this.row(rowNumber).cell(columnNameOrNumber);
             })
             .handle(arguments);
@@ -358,6 +363,8 @@ class Sheet {
                 return new Range(startCell, endCell);
             })
             .case(['number', '*', 'number', '*'], (startRowNumber, startColumnNameOrNumber, endRowNumber, endColumnNameOrNumber) => {
+                indexValidation.validateIndex(startRowNumber, "row");
+                indexValidation.validateIndex(endRowNumber, "row");
                 return this.range(this.cell(startRowNumber, startColumnNameOrNumber), this.cell(endRowNumber, endColumnNameOrNumber));
             })
             .handle(arguments);
@@ -383,6 +390,8 @@ class Sheet {
      * @returns {Row} The row with the given number.
      */
     row(rowNumber) {
+        indexValidation.validateIndex(rowNumber, "row");
+
         if (this._rows[rowNumber]) return this._rows[rowNumber];
 
         const rowNode = {

--- a/lib/indexValidation.js
+++ b/lib/indexValidation.js
@@ -1,0 +1,9 @@
+"use strict";
+
+module.exports = {
+    validateIndex(index, kind) {
+        if (index < 1) {
+            throw new RangeError("Invaid " + kind + " index " + index + ". Remember that spreadsheets use 1 indexing.");
+        }
+    }
+};

--- a/lib/indexValidation.js
+++ b/lib/indexValidation.js
@@ -1,6 +1,17 @@
 "use strict";
 
+/**
+ * Index validation.
+ * @private
+ */
 module.exports = {
+    /**
+     * Validate the given index against the 1 indexing system used for
+     * spreadsheets. If the index is below 1, then a RangeError is thrown with
+     * a helpful error message.
+     * @param {number} index - The index to validate.
+     * @param {string} kind - The type of index (row, column, etc.).
+     */
     validateIndex(index, kind) {
         if (index < 1) {
             throw new RangeError("Invaid " + kind + " index " + index + ". Remember that spreadsheets use 1 indexing.");

--- a/test/unit/Column.spec.js
+++ b/test/unit/Column.spec.js
@@ -80,6 +80,18 @@ describe("Column", () => {
             expect(column.cell(7)).toBe('CELL');
             expect(sheet.cell).toHaveBeenCalledWith(7, 5);
         });
+
+        it("should throw an exception on an index of 0", () => {
+            expect(() => column.cell(0)).toThrow(
+                new RangeError("Invaid row index 0. Remember that spreadsheets use 1 indexing.")
+            );
+        });
+
+        it("should throw an exception on an index of -1", () => {
+            expect(() => column.cell(-1)).toThrow(
+                new RangeError("Invaid row index -1. Remember that spreadsheets use 1 indexing.")
+            );
+        });
     });
 
     describe("columnName", () => {

--- a/test/unit/Row.spec.js
+++ b/test/unit/Row.spec.js
@@ -115,6 +115,18 @@ describe("Row", () => {
             expect(row.cell('C')).toEqual(jasmine.any(Cell));
             expect(Cell).toHaveBeenCalledWith(row, 3, 3);
         });
+
+        it("should throw an exception on an index of 0", () => {
+            expect(() => row.cell(0)).toThrow(
+                new RangeError("Invaid column index 0. Remember that spreadsheets use 1 indexing.")
+            );
+        });
+
+        it("should throw an exception on an index of -1", () => {
+            expect(() => row.cell(-1)).toThrow(
+                new RangeError("Invaid column index -1. Remember that spreadsheets use 1 indexing.")
+            );
+        });
     });
 
     describe("height", () => {
@@ -281,6 +293,18 @@ describe("Row", () => {
             expect(row.hasCell(1)).toBe(false);
             expect(row.hasCell(2)).toBe(true);
             expect(row.hasCell(3)).toBe(false);
+        });
+
+        it("should throw an exception on an index of 0", () => {
+            expect(() => row.hasCell(0)).toThrow(
+                new RangeError("Invaid column index 0. Remember that spreadsheets use 1 indexing.")
+            );
+        });
+
+        it("should throw an exception on an index of -1", () => {
+            expect(() => row.hasCell(-1)).toThrow(
+                new RangeError("Invaid column index -1. Remember that spreadsheets use 1 indexing.")
+            );
         });
     });
 

--- a/test/unit/Sheet.spec.js
+++ b/test/unit/Sheet.spec.js
@@ -151,6 +151,33 @@ describe("Sheet", () => {
 
             expect(sheet.cell).toHaveBeenCalledWith(5, 4);
         });
+
+        it("should throw an exception on a row number of 0", () => {
+            expect(() => sheet.activeCell(0, 1)).toThrow(
+                new RangeError("Invaid row index 0. Remember that spreadsheets use 1 indexing.")
+            );
+            expect(() => sheet.activeCell("A0")).toThrow(
+                new RangeError("Invaid row index 0. Remember that spreadsheets use 1 indexing.")
+            );
+        });
+
+        it("should throw an exception on a row number of -1", () => {
+            expect(() => sheet.activeCell(-1, 1)).toThrow(
+                new RangeError("Invaid row index -1. Remember that spreadsheets use 1 indexing.")
+            );
+        });
+
+        it("should throw an exception on a column number of 0", () => {
+            expect(() => sheet.activeCell(1, 0)).toThrow(
+                new RangeError("Invaid column index 0. Remember that spreadsheets use 1 indexing.")
+            );
+        });
+
+        it("should throw an exception on a column number of -1", () => {
+            expect(() => sheet.activeCell(1, -1)).toThrow(
+                new RangeError("Invaid column index -1. Remember that spreadsheets use 1 indexing.")
+            );
+        });
     });
 
     describe("cell", () => {
@@ -170,6 +197,33 @@ describe("Sheet", () => {
             expect(sheet.cell(5, 7)).toBe("CELL");
             expect(sheet.row).toHaveBeenCalledWith(5);
             expect(cell).toHaveBeenCalledWith(7);
+        });
+
+        it("should throw an exception on a row number of 0", () => {
+            expect(() => sheet.cell(0, 1)).toThrow(
+                new RangeError("Invaid row index 0. Remember that spreadsheets use 1 indexing.")
+            );
+            expect(() => sheet.cell("A0")).toThrow(
+                new RangeError("Invaid row index 0. Remember that spreadsheets use 1 indexing.")
+            );
+        });
+
+        it("should throw an exception on a row number of -1", () => {
+            expect(() => sheet.cell(-1, 1)).toThrow(
+                new RangeError("Invaid row index -1. Remember that spreadsheets use 1 indexing.")
+            );
+        });
+
+        it("should throw an exception on a column number of 0", () => {
+            expect(() => sheet.cell(1, 0)).toThrow(
+                new RangeError("Invaid column index 0. Remember that spreadsheets use 1 indexing.")
+            );
+        });
+
+        it("should throw an exception on a column number of -1", () => {
+            expect(() => sheet.cell(1, -1)).toThrow(
+                new RangeError("Invaid column index -1. Remember that spreadsheets use 1 indexing.")
+            );
         });
     });
 
@@ -253,6 +307,18 @@ describe("Sheet", () => {
                     children: []
                 }
             ]);
+        });
+
+        it("should throw an exception on a column number of 0", () => {
+            expect(() => sheet.activeCell(1, 0)).toThrow(
+                new RangeError("Invaid column index 0. Remember that spreadsheets use 1 indexing.")
+            );
+        });
+
+        it("should throw an exception on a column number of -1", () => {
+            expect(() => sheet.activeCell(1, -1)).toThrow(
+                new RangeError("Invaid column index -1. Remember that spreadsheets use 1 indexing.")
+            );
         });
     });
 
@@ -394,6 +460,42 @@ describe("Sheet", () => {
             expect(sheet.range(1, 'B', 3, 'D')).toEqual(jasmine.any(Range));
             expect(Range).toHaveBeenCalledWith([1, 'B'], [3, 'D']);
         });
+
+        it("should throw an exception on a row number of 0", () => {
+            expect(() => sheet.range(0, 1, 1, 1)).toThrow(
+                new RangeError("Invaid row index 0. Remember that spreadsheets use 1 indexing.")
+            );
+            expect(() => sheet.range(1, 1, 0, 1)).toThrow(
+                new RangeError("Invaid row index 0. Remember that spreadsheets use 1 indexing.")
+            );
+        });
+
+        it("should throw an exception on a row number of -1", () => {
+            expect(() => sheet.range(-1, 1, 1, 1)).toThrow(
+                new RangeError("Invaid row index -1. Remember that spreadsheets use 1 indexing.")
+            );
+            expect(() => sheet.range(1, 1, -1, 1)).toThrow(
+                new RangeError("Invaid row index -1. Remember that spreadsheets use 1 indexing.")
+            );
+        });
+
+        it("should throw an exception on a column number of 0", () => {
+            expect(() => sheet.range(1, 0, 1, 1)).toThrow(
+                new RangeError("Invaid column index 0. Remember that spreadsheets use 1 indexing.")
+            );
+            expect(() => sheet.range(1, 1, 1, 0)).toThrow(
+                new RangeError("Invaid column index 0. Remember that spreadsheets use 1 indexing.")
+            );
+        });
+
+        it("should throw an exception on a column number of -1", () => {
+            expect(() => sheet.range(1, -1, 1, 1)).toThrow(
+                new RangeError("Invaid column index -1. Remember that spreadsheets use 1 indexing.")
+            );
+            expect(() => sheet.range(1, 1, 1, -1)).toThrow(
+                new RangeError("Invaid column index -1. Remember that spreadsheets use 1 indexing.")
+            );
+        });
     });
 
     describe("autoFilter", () => {
@@ -449,6 +551,18 @@ describe("Sheet", () => {
                 },
                 children: []
             });
+        });
+
+        it("should throw an exception on a row number of 0", () => {
+            expect(() => sheet.row(0)).toThrow(
+                new RangeError("Invaid row index 0. Remember that spreadsheets use 1 indexing.")
+            );
+        });
+
+        it("should throw an exception on a row number of -1", () => {
+            expect(() => sheet.row(-1)).toThrow(
+                new RangeError("Invaid row index -1. Remember that spreadsheets use 1 indexing.")
+            );
         });
     });
 

--- a/test/unit/indexValidation.spec.js
+++ b/test/unit/indexValidation.spec.js
@@ -1,0 +1,39 @@
+"use strict";
+
+const proxyquire = require("proxyquire");
+
+describe("indexValidation", () => {
+    let indexValidation;
+
+    beforeEach(() => {
+        indexValidation = proxyquire("../../lib/indexValidation", {
+            '@noCallThru': true
+        });
+    });
+
+    describe("validateIndex", () => {
+        it("should do nothing for an index of 1", () => {
+            indexValidation.validateIndex(1, "column");
+        });
+
+        it("should throw an exception for an index of 0", () => {
+            expect(() => indexValidation.validateIndex(0, "column")).toThrow(
+                new RangeError("Invaid column index 0. Remember that spreadsheets use 1 indexing.")
+            );
+
+            expect(() => indexValidation.validateIndex(0, "row")).toThrow(
+                new RangeError("Invaid row index 0. Remember that spreadsheets use 1 indexing.")
+            );
+        });
+
+        it("should throw an exception for an index of -1", () => {
+            expect(() => indexValidation.validateIndex(-1, "column")).toThrow(
+                new RangeError("Invaid column index -1. Remember that spreadsheets use 1 indexing.")
+            );
+
+            expect(() => indexValidation.validateIndex(-1, "row")).toThrow(
+                new RangeError("Invaid row index -1. Remember that spreadsheets use 1 indexing.")
+            );
+        });
+    });
+});


### PR DESCRIPTION
Add index validation to the methods of the Sheet, Row, and Column classes. With these changes, if you pass a 0 or negative value as a row or column index then a RangeError is thrown.

```
> sheet.cell(0, 1);
RangeError: Invaid row index 0. Remember that spreadsheets use 1 indexing.
```

This helps to prevent invalid spreadsheets that could be successfully generated, but be rejected by Excel as being corrupted (see #111).

I wrote a bunch of test cases for different places that invalid indices could be passed in, let me know if there are any other cases I should cover.

Also some of the test cases seem to be failing oddly, see `Sheet activeCell should throw an exception on a row number of 0`. This should lead to `sheet.activeCell` calling `this.cell` which should then be performing the validation on the row index, however the exception is not being thrown in the test. When I actually compile the code with gulp and run similar test in my browser it does throw the exception.

```
> XlsxPopulate.fromBlankAsync().then(workbook => workbook.sheet(0).activeCell(0, 1));
RangeError: Invaid row index 0. Remember that spreadsheets use 1 indexing.
```