### PR TITLE
docs(Cell): fixed return type of columnName

### DIFF
--- a/lib/Cell.js
+++ b/lib/Cell.js
@@ -95,7 +95,7 @@ class Cell {
 
     /**
      * Gets the column name of the cell.
-     * @returns {number} The column name.
+     * @returns {string} The column name.
      */
     columnName() {
         return addressConverter.columnNumberToName(this.columnNumber());


### PR DESCRIPTION
The API documentation indicates `Cell.columnName()` returns `number`. Seems like an oversight?

[Cell.columnName()](https://github.com/dtjohnson/xlsx-populate/blob/80d2f5d64084f6a7faa2864c6212dbd809c95f7b/lib/Cell.js#L101)
[addressConverter.columnNumberToName()](https://github.com/dtjohnson/xlsx-populate/blob/80d2f5d64084f6a7faa2864c6212dbd809c95f7b/lib/addressConverter.js#L36)