### PR TITLE
Force sheetname to be a string

### DIFF
--- a/lib/Sheet.js
+++ b/lib/Sheet.js
@@ -319,7 +319,7 @@ class Sheet {
     name() {
         return new ArgHandler('Sheet.name')
             .case(() => {
-                return this._idNode.attributes.name;
+                return `${this._idNode.attributes.name}`;
             })
             .case('string', name => {
                 this._idNode.attributes.name = name;

--- a/test/unit/Sheet.spec.js
+++ b/test/unit/Sheet.spec.js
@@ -359,6 +359,20 @@ describe("Sheet", () => {
             expect(sheet.name("a new name")).toBe(sheet);
             expect(sheet.name()).toBe("a new name");
         });
+
+        it("sheet name should be a string", () => {
+            idNode = {
+                name: 'sheet',
+                attributes: {
+                    name: 1,
+                    sheetId: '1',
+                    'r:id': 'rId1'
+                },
+                children: []
+            };
+            sheet = new Sheet(workbook, idNode, sheetNode);
+            expect(sheet.name()).toBe("1");
+        });
     });
 
     describe("range", () => {


### PR DESCRIPTION
### Force sheetname to be a string
Some error will occure when sheet name is number, i.e. `"1"`, `"2"`. 
One example error is cannot get sheet by `workbook.sheet('1')`.

Example File: [TF33674675.xlsx](https://github.com/dtjohnson/xlsx-populate/files/2961901/TF33674675.xlsx)
