### PR TITLE
docs(Range): name parameters in style calls

### DIFF
--- a/lib/Range.js
+++ b/lib/Range.js
@@ -259,12 +259,12 @@ class Range {
      *//**
      * Set the style in each cell to the result of a function called for each.
      * @param {string} name - The name of the style.
-     * @param {Range~mapCallback} - The callback to provide value for the cell.
+     * @param {Range~mapCallback} callback - The callback to provide value for the cell.
      * @returns {Range} The range.
      *//**
      * Sets the style in each cell to the corresponding value in the given 2D array of values.
      * @param {string} name - The name of the style.
-     * @param {Array.<Array.<*>>} - The style values to set.
+     * @param {Array.<Array.<*>>} values - The style values to set.
      * @returns {Range} The range.
      *//**
      * Set the style of all cells in the range to a single style value.


### PR DESCRIPTION
Gave names to parameters in `.style()` calls to differentiate them in summary.

Before this change:
https://www.npmjs.com/package/xlsx-populate#Range
```
.style(name) ⇒ Array.<Array.<*>>
.style(names) ⇒ Object.<string, Array.<Array.<*>>>
.style(name) ⇒ Range
.style(name) ⇒ Range
.style(name, value) ⇒ Range
.style(styles) ⇒ Range
.style(style) ⇒ Range
```
Note that the 3rd and 4th are identical in appearance.