### PR TITLE
Fix Workbook.outputAsync returns type

### DIFF
--- a/lib/Workbook.js
+++ b/lib/Workbook.js
@@ -239,13 +239,13 @@ class Workbook {
     /**
      * Generates the workbook output.
      * @param {string} [type] - The type of the data to return: base64, binarystring, uint8array, arraybuffer, blob, nodebuffer. Defaults to 'nodebuffer' in Node.js and 'blob' in browsers.
-     * @returns {string|Uint8Array|ArrayBuffer|Blob|Buffer} The data.
+     * @returns {Promise<string|Uint8Array|ArrayBuffer|Blob|Buffer>} The data.
      *//**
      * Generates the workbook output.
      * @param {{}} [opts] Options
      * @param {string} [opts.type] - The type of the data to return: base64, binarystring, uint8array, arraybuffer, blob, nodebuffer. Defaults to 'nodebuffer' in Node.js and 'blob' in browsers.
      * @param {string} [opts.password] - The password to use to encrypt the workbook.
-     * @returns {string|Uint8Array|ArrayBuffer|Blob|Buffer} The data.
+     * @returns {Promise<string|Uint8Array|ArrayBuffer|Blob|Buffer>} The data.
      */
     outputAsync(opts) {
         opts = opts || {};


### PR DESCRIPTION
The JSDoc's returns type of `Workbook.outputAsync` should be a `Promise`.